### PR TITLE
fix: update to new URLs for Bells Corners

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ div {
         align="top"
         frameborder="0"
         allowtransparency="true"
-        src="https://weather.gc.ca/city/pages/on-118_metric_e.html#mainContent">
+        src="https://weather.gc.ca/en/location/index.html?coords=45.321,-75.828#mainContent">
       Observations: Ottawa, Ontario, Canada
       </iframe>
     </div>
@@ -60,7 +60,7 @@ div {
         align="top"
         frameborder="0"
         allowtransparency="true"
-        src="https://weather.gc.ca/forecast/hourly/on-118_metric_e.html#wb-cont">
+        src="https://weather.gc.ca/en/forecast/hourly/index.html?coords=45.321,-75.828#wb-cont">
         Forecast: Ottawa, Ontario, Canada
       </iframe>
     </div>


### PR DESCRIPTION
The old URLs were reporting:

> We're sorry, the page you have tried to access is no longer available. We've recently increased the number of locations we offer weather information for and as a result have updated our URL structure. We understand this can be inconvenient, however we are here to help you find the information you need.

The new URLs are again showing relevant information.

Mission accomplished!